### PR TITLE
Adding the code owners for the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @scuttlerobot/ros-contributors will be requested for
+# review when someone opens a pull request.
+@scuttlerobot/ros-contributors


### PR DESCRIPTION
Make `ros-contributors` the owner of this repository